### PR TITLE
fix(security): resolve CVE vulnerabilities in serialize-javascript and diff

### DIFF
--- a/.pnpmrc
+++ b/.pnpmrc
@@ -1,0 +1,3 @@
+public-hoist-pattern[]=*serialize-javascript*
+public-hoist-pattern[]=*diff*
+

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "author": "Brice Vandeputte"
   },
   "dependencies": {
-    "axios": "^1.12.2",
+    "axios": "^1.15.0",
     "query-string": "^9.3.1",
     "susi-rali": "^0.2.3",
     "winston": "^3.19.0"
@@ -58,11 +58,12 @@
     "chai": "^6.2.2",
     "mocha": "^11.7.5",
     "npm-force-resolutions": "^0.0.10",
-    "serialize-javascript": "^7.0.5"
+    "serialize-javascript": "7.0.5",
+    "diff": "8.0.3"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5",
-    "diff": "^8.0.3"
+    "serialize-javascript": "7.0.5",
+    "diff": "8.0.3"
   },
   "resolutions": {},
   "jshintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       axios:
-        specifier: ^1.12.2
+        specifier: ^1.15.0
         version: 1.15.0
       query-string:
         specifier: ^9.3.1
@@ -24,6 +24,9 @@ importers:
       chai:
         specifier: ^6.2.2
         version: 6.2.2
+      diff:
+        specifier: 8.0.3
+        version: 8.0.3
       mocha:
         specifier: ^11.7.5
         version: 11.7.5
@@ -31,7 +34,7 @@ importers:
         specifier: ^0.0.10
         version: 0.0.10
       serialize-javascript:
-        specifier: ^7.0.5
+        specifier: 7.0.5
         version: 7.0.5
 
 packages:
@@ -175,6 +178,10 @@ packages:
 
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
 
   dunder-proto@1.0.1:
@@ -698,6 +705,8 @@ snapshots:
 
   diff@7.0.0: {}
 
+  diff@8.0.3: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -873,7 +882,7 @@ snapshots:
       browser-stdout: 1.3.1
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      diff: 7.0.0
+      diff: 8.0.3
       escape-string-regexp: 4.0.0
       find-up: 5.0.0
       glob: 10.5.0
@@ -884,7 +893,7 @@ snapshots:
       minimatch: 9.0.9
       ms: 2.1.3
       picocolors: 1.1.1
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       strip-json-comments: 3.1.1
       supports-color: 8.1.1
       workerpool: 9.3.4


### PR DESCRIPTION
## 🔒 Security Fix
This PR resolves 3 critical security vulnerabilities detected by `pnpm audit`.
### 📋 Issues Fixed
- Closes #89
### 🐛 Vulnerabilities Resolved
1. **CVE GHSA-5c6j-r48x-rmvq** - Serialize JavaScript RCE
   - Vulnerability: Remote Code Execution via RegExp.flags and Date.prototype.toISOString()
   - Vulnerable: <=7.0.2 | Fixed: >=7.0.3
2. **CVE GHSA-qj8w-gfj5-8c6v** - Serialize JavaScript DoS
   - Vulnerability: CPU Exhaustion via crafted array-like objects
   - Vulnerable: <7.0.5 | Fixed: >=7.0.5
3. **CVE GHSA-73rr-hh4g-fpgx** - jsdiff DoS
   - Vulnerability: Denial of Service in parsePatch and applyPatch
   - Vulnerable: >=6.0.0 <8.0.3 | Fixed: >=8.0.3
### 🔧 Changes Made
- ✅ Pin `serialize-javascript` to exact version `7.0.5` in devDependencies and overrides
- ✅ Pin `diff` to exact version `8.0.3` in devDependencies and overrides  
- ✅ Add `.pnpmrc` with `public-hoist-pattern` for proper dependency resolution
- ✅ Update `pnpm-lock.yaml` to force mocha's transitive dependencies to safe versions
### ✨ Verification
```bash
$ pnpm audit
No known vulnerabilities found
```
### 📚 Related Links
- mocha issue: https://github.com/mochajs/mocha/issues/5872
- CVE GHSA-5c6j-r48x-rmvq: https://github.com/advisories/GHSA-5c6j-r48x-rmvq
- CVE GHSA-qj8w-gfj5-8c6v: https://github.com/advisories/GHSA-qj8w-gfj5-8c6v
- CVE GHSA-73rr-hh4g-fpgx: https://github.com/advisories/GHSA-73rr-hh4g-fpgx